### PR TITLE
Add silent argument to npm task

### DIFF
--- a/doc/tasks/npm_script.md
+++ b/doc/tasks/npm_script.md
@@ -12,6 +12,7 @@ parameters:
             triggered_by: [js, jsx, coffee, ts, less, sass, scss]
             working_directory: "./"
             is_run_task: false
+            silent: false
 ```
 
 **script**
@@ -46,3 +47,9 @@ This option specifies in which directory the NPM script should be run.
 *Default: false*
 
 This option will append 'run' to the npm command to make it possible to run custom npm scripts.
+
+**silent**
+
+*Default: false*
+
+This option will append '--silent' to the npm script to supress `npm ERR!` messages from showing.

--- a/src/Task/NpmScript.php
+++ b/src/Task/NpmScript.php
@@ -29,12 +29,14 @@ class NpmScript extends AbstractExternalTask
             'triggered_by' => ['js', 'jsx', 'coffee', 'ts', 'less', 'sass', 'scss'],
             'working_directory' => './',
             'is_run_task' => false,
+            'silent' => false,
         ]);
 
         $resolver->addAllowedTypes('script', ['string']);
         $resolver->addAllowedTypes('triggered_by', ['array']);
         $resolver->addAllowedTypes('working_directory', ['string']);
         $resolver->addAllowedTypes('is_run_task', ['bool']);
+        $resolver->addAllowedTypes('silent', ['bool']);
 
         return $resolver;
     }
@@ -61,6 +63,7 @@ class NpmScript extends AbstractExternalTask
         $arguments = $this->processBuilder->createArgumentsForCommand('npm');
         $arguments->addOptionalArgument('run', $config['is_run_task']);
         $arguments->addRequiredArgument('%s', $config['script']);
+        $arguments->addOptionalArgument('--silent', $config['silent']);
 
         $process = $this->processBuilder->buildProcess($arguments);
         $process->setWorkingDirectory(realpath($config['working_directory']));


### PR DESCRIPTION
This PR adds a `silent` argument to the npm task which appends `--silent` to the script that will be ran. This suppresses `npm ERR!` messages from showing.